### PR TITLE
Fix aborting if one fails; reduce timeout to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [1.0.1] - 2019-04-23
+### Changed
+- Set the API request timeout to 30 seconds (down from the default of 100).
+
+### Fixed
+- Don't abort all hosts if one Screenly fails.
+
 ## [1.0.0] - 2019-04-23
 ### Added
 - Uses [Screenly OSE API](http://ose.demo.screenlyapp.com/api/docs/) `v1` to support most installations.
@@ -13,4 +20,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Can be provided with a list of IP addresses or hostnames or a single IP address or hostname.
 - Settings can be specified on the commandline or via environment variables (so it can be run in [Docker](https://docker.com/).
 
+[1.0.1]: https://github.com/mcld/greatreadingadventure/tree/v1.0.1
 [1.0.0]: https://github.com/mcld/greatreadingadventure/tree/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ScreenlyManager
 ScreenlyManager is a cross-platform commandline program written using [.NET Core 2.2](https://dotnet.microsoft.com/download/dotnet-core/2.2) to facilitate management of [Screenly OSE](https://www.screenly.io/ose/) installations.
 
-**The latest release is [Version 1.0.0](https://github.com/mcld/ScreenlyManager/releases/latest).**
+**The latest release is [Version 1.0.1](https://github.com/mcld/ScreenlyManager/releases/latest).**
 
 Current features:
 

--- a/ScreenlyManager/Program.cs
+++ b/ScreenlyManager/Program.cs
@@ -57,6 +57,7 @@ namespace ScreenlyManager
         private const string InvalidAssets = "Unable to fetch assets, error: {0}";
         private const string InvalidDeletion = "Error deleting asset {0}: {1}";
         private const string InvalidNoAddress = "No addresses specified.";
+        private const string InvalidWebRequest = "A problem happened querying the API: {0}";
 
         private const string HttpValue = "http://";
         private const string HttpsValue = "https://";
@@ -172,7 +173,19 @@ namespace ScreenlyManager
                                 = new AuthenticationHeaderValue("Basic", authentication);
                         }
 
-                        var response = await client.GetAsync(url);
+                        client.Timeout = TimeSpan.FromSeconds(30);
+
+                        HttpResponseMessage response = null;
+                        try
+                        {
+                            response = await client.GetAsync(url);
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine(string.Format(InvalidWebRequest, ex.Message));
+                            continue;
+                        }
+
                         if (!response.IsSuccessStatusCode)
                         {
                             Console.WriteLine(string.Format(InvalidAssets, response.StatusCode));

--- a/ScreenlyManager/ScreenlyManager.csproj
+++ b/ScreenlyManager/ScreenlyManager.csproj
@@ -8,14 +8,13 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2019 Maricopa County Library District</Copyright>
     <Description>ScreenlyManager provides a command-line interface for working with the Screenly OSE API.</Description>
-    <FileVersion>1.0.0</FileVersion>
     <PackageLicenseUrl>https://github.com/mcld/ScreenlyManager/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/mcld/ScreenlyManager/</PackageProjectUrl>
     <PackageReleaseNotes>See https://github.com/mcld/ScreenlyManager/releases/latest</PackageReleaseNotes>
     <Product>ScreenlyManager</Product>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/ScreenlyManager/</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Set the API request timeout to 30 seconds (down from the default of 100).
- Don't abort all hosts if one Screenly fails.